### PR TITLE
fix: add height:100% to super-tabs-container

### DIFF
--- a/core/src/super-tabs-container/super-tabs-container.component.scss
+++ b/core/src/super-tabs-container/super-tabs-container.component.scss
@@ -6,6 +6,7 @@
   position: relative;
   box-sizing: content-box;
   width: 100%;
+  height: 100%;
   overflow: hidden;
   transform: translate3d(0,0,0);
   touch-action: pan-y;


### PR DESCRIPTION
The super tabs container was not visible in Safari due to a css bug. This minor fix solves the issue 🎉 