### PR TITLE
fix: set generic type for ModuleWithProviders

### DIFF
--- a/angular/src/super-tabs.module.ts
+++ b/angular/src/super-tabs.module.ts
@@ -17,7 +17,7 @@ export const DECLARATIONS = [
   imports: [CommonModule],
 })
 export class SuperTabsModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<SuperTabsModule> {
     return {
       ngModule: SuperTabsModule,
       providers: [


### PR DESCRIPTION
Usage without a generic type is deprecated for ModuleWithProviders. See https://angular.io/api/core/ModuleWithProviders

Fix #460 